### PR TITLE
On Amazon Linux we do not have setproctitle

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -51,7 +51,12 @@ class logentries::dependencies {
         gpgkey   => 'http://rep.logentries.com/RPM-GPG-KEY-logentries',
       }
 
-      package { [ 'python-setproctitle', 'python-simplejson' ]:
+      $req_packages = $::operatingsystem ?{
+        'Amazon' => [ 'python27-simplejson' ] ,
+        default  => [ 'python-setproctitle', 'python-simplejson' ]
+      }
+
+      package { $req_packages :
         ensure  => latest,
         require => Yumrepo['logentries']
       }


### PR DESCRIPTION
On Amazon Linux setproctitle is not provided, I also checked on logentries code, and it can work without this library (they have a failsafe for when this library is not there).